### PR TITLE
Bind camera target after scene changes

### DIFF
--- a/Assets/CameraFollow2D.cs
+++ b/Assets/CameraFollow2D.cs
@@ -1,10 +1,33 @@
 // Scripts/Rendering/CameraFollow2D.cs
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 public class CameraFollow2D : MonoBehaviour
 {
     [SerializeField] Transform target;
     [SerializeField] float smooth = 20f;
+
+    private void OnEnable()
+    {
+        SceneManager.sceneLoaded += OnSceneLoaded;
+        RebindTarget();
+    }
+
+    private void OnDisable()
+    {
+        SceneManager.sceneLoaded -= OnSceneLoaded;
+    }
+
+    private void OnSceneLoaded(Scene scene, LoadSceneMode mode)
+    {
+        RebindTarget();
+    }
+
+    public void RebindTarget()
+    {
+        target = FindObjectOfType<PlayerController>()?.transform;
+    }
+
     void LateUpdate()
     {
         if (!target) return;

--- a/Assets/PlayerPersistence.cs
+++ b/Assets/PlayerPersistence.cs
@@ -62,6 +62,7 @@ public sealed class PlayerPersistence : MonoBehaviour
         {
             Vector3 world = grid.GetCellCenterWorld(pendingSpawnCell);
             transform.position = new Vector3(world.x, world.y, transform.position.z);
+            FindObjectOfType<CameraFollow2D>()?.RebindTarget();
             hasPendingSpawn = false;
         }
     }


### PR DESCRIPTION
## Summary
- Rebind the camera to the player whenever scenes load so it always follows the active player
- Immediately retarget the camera after respawning to snap view to the player

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b75eef7a288320b07d52912437cbed