### PR TITLE
Implement data-driven Pokémon definitions and party system

### DIFF
--- a/Assets/PokemonData.meta
+++ b/Assets/PokemonData.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ef27bd50-43a7-46f8-a557-43c09b3fb158
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PokemonData/pokemon.csv
+++ b/Assets/PokemonData/pokemon.csv
@@ -1,0 +1,3 @@
+identifier,displayName,description,hp,attack,defense,spAttack,spDefense,speed
+bulbasaur,Bulbasaur,A strange seed was planted on its back at birth.,45,49,49,65,65,45
+charmander,Charmander,Obviously prefers hot places.,39,52,43,60,50,65

--- a/Assets/PokemonData/pokemon.csv.meta
+++ b/Assets/PokemonData/pokemon.csv.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 123aca63-2a02-4ea5-9ee7-33fd802f44b7
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -12,6 +12,7 @@ GameObject:
   - component: {fileID: 6155662578165263807}
   - component: {fileID: 797413776316536669}
   - component: {fileID: 8358638134395886477}
+  - component: {fileID: 18044183696933120604}
   m_Layer: 0
   m_Name: Player
   m_TagString: Untagged
@@ -157,3 +158,17 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
+--- !u!114 &18044183696933120604
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8758864144063954263}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ddec3365-ae7f-46af-8db3-ab35be9455d1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  maxSize: 6
+

--- a/Assets/Scripts.meta
+++ b/Assets/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3abb8320-9a3c-42a4-afd9-751e841ed2c6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Pokemon.meta
+++ b/Assets/Scripts/Pokemon.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2267b724-6ff5-4712-82ee-ab8982374428
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Pokemon/Editor.meta
+++ b/Assets/Scripts/Pokemon/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1e6cbae9-2f30-4476-a8d1-661cb5c3fe3c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Pokemon/Editor/PokemonDefinitionImporter.cs
+++ b/Assets/Scripts/Pokemon/Editor/PokemonDefinitionImporter.cs
@@ -1,0 +1,52 @@
+#if UNITY_EDITOR
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+
+public static class PokemonDefinitionImporter
+{
+    [MenuItem("Pokemon/Import Definitions From CSV")]
+    public static void ImportFromCsv()
+    {
+        string path = EditorUtility.OpenFilePanel("Pokemon CSV", Application.dataPath, "csv");
+        if (string.IsNullOrEmpty(path))
+            return;
+
+        string folder = "Assets/PokemonData/Definitions";
+        if (!AssetDatabase.IsValidFolder("Assets/PokemonData"))
+            AssetDatabase.CreateFolder("Assets", "PokemonData");
+        if (!AssetDatabase.IsValidFolder(folder))
+            AssetDatabase.CreateFolder("Assets/PokemonData", "Definitions");
+
+        var lines = File.ReadAllLines(path);
+        for (int i = 1; i < lines.Length; i++)
+        {
+            var line = lines[i];
+            if (string.IsNullOrWhiteSpace(line))
+                continue;
+            var cols = line.Split(',');
+            if (cols.Length < 9)
+                continue;
+
+            var def = ScriptableObject.CreateInstance<PokemonDefinition>();
+            def.identifier = cols[0].Trim();
+            def.displayName = cols[1].Trim();
+            def.description = cols[2].Trim();
+            def.baseStats = new PokemonBaseStats
+            {
+                hp = int.Parse(cols[3]),
+                attack = int.Parse(cols[4]),
+                defense = int.Parse(cols[5]),
+                specialAttack = int.Parse(cols[6]),
+                specialDefense = int.Parse(cols[7]),
+                speed = int.Parse(cols[8])
+            };
+
+            AssetDatabase.CreateAsset(def, $"{folder}/{def.identifier}.asset");
+        }
+
+        AssetDatabase.SaveAssets();
+        AssetDatabase.Refresh();
+    }
+}
+#endif

--- a/Assets/Scripts/Pokemon/Editor/PokemonDefinitionImporter.cs.meta
+++ b/Assets/Scripts/Pokemon/Editor/PokemonDefinitionImporter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e9f7a962-1f16-494a-87ec-7ddceec319d2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Pokemon/PokemonBaseStats.cs
+++ b/Assets/Scripts/Pokemon/PokemonBaseStats.cs
@@ -1,0 +1,13 @@
+using System;
+using UnityEngine;
+
+[Serializable]
+public struct PokemonBaseStats
+{
+    public int hp;
+    public int attack;
+    public int defense;
+    public int specialAttack;
+    public int specialDefense;
+    public int speed;
+}

--- a/Assets/Scripts/Pokemon/PokemonBaseStats.cs.meta
+++ b/Assets/Scripts/Pokemon/PokemonBaseStats.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 23197044-8d49-472b-8bac-7fbe1d8ce05d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Pokemon/PokemonDatabase.cs
+++ b/Assets/Scripts/Pokemon/PokemonDatabase.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "Pokemon/Database")]
+public class PokemonDatabase : ScriptableObject
+{
+    [SerializeField]
+    private List<PokemonDefinition> definitions = new();
+
+    private Dictionary<string, PokemonDefinition> lookup;
+
+    private void OnEnable()
+    {
+        BuildLookup();
+    }
+
+    private void BuildLookup()
+    {
+        lookup = new Dictionary<string, PokemonDefinition>();
+        foreach (var def in definitions)
+        {
+            if (def == null || string.IsNullOrEmpty(def.identifier))
+                continue;
+            lookup[def.identifier] = def;
+        }
+    }
+
+    public PokemonDefinition GetById(string id)
+    {
+        if (lookup == null || lookup.Count != definitions.Count)
+            BuildLookup();
+        lookup.TryGetValue(id, out var def);
+        return def;
+    }
+}

--- a/Assets/Scripts/Pokemon/PokemonDatabase.cs.meta
+++ b/Assets/Scripts/Pokemon/PokemonDatabase.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 77fe0631-f451-4c59-a5a2-830a5e4bb994
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Pokemon/PokemonDefinition.cs
+++ b/Assets/Scripts/Pokemon/PokemonDefinition.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "Pokemon/Definition")]
+public class PokemonDefinition : ScriptableObject
+{
+    public string identifier;
+    public string displayName;
+    [TextArea]
+    public string description;
+    public PokemonBaseStats baseStats;
+
+    public string Identifier => identifier;
+}

--- a/Assets/Scripts/Pokemon/PokemonDefinition.cs.meta
+++ b/Assets/Scripts/Pokemon/PokemonDefinition.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b6cdb2dc-3326-482e-9fb4-abcf8296ac5b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Pokemon/PokemonInstance.cs
+++ b/Assets/Scripts/Pokemon/PokemonInstance.cs
@@ -1,0 +1,49 @@
+using UnityEngine;
+
+public class PokemonInstance
+{
+    public PokemonDefinition Definition { get; private set; }
+    public int Level { get; private set; }
+
+    public int MaxHP { get; private set; }
+    public int Attack { get; private set; }
+    public int Defense { get; private set; }
+    public int SpecialAttack { get; private set; }
+    public int SpecialDefense { get; private set; }
+    public int Speed { get; private set; }
+
+    private PokemonInstance() { }
+
+    public static PokemonInstance Create(PokemonDefinition definition, int level)
+    {
+        var instance = new PokemonInstance
+        {
+            Definition = definition,
+            Level = Mathf.Max(1, level)
+        };
+        instance.RecalculateStats();
+        return instance;
+    }
+
+    public void RecalculateStats()
+    {
+        int l = Mathf.Max(1, Level);
+        var stats = Definition.baseStats;
+        MaxHP = CalculateHp(stats.hp, l);
+        Attack = CalculateStat(stats.attack, l);
+        Defense = CalculateStat(stats.defense, l);
+        SpecialAttack = CalculateStat(stats.specialAttack, l);
+        SpecialDefense = CalculateStat(stats.specialDefense, l);
+        Speed = CalculateStat(stats.speed, l);
+    }
+
+    private static int CalculateHp(int baseStat, int level)
+    {
+        return Mathf.FloorToInt(((2 * baseStat) * level) / 100f) + level + 10;
+    }
+
+    private static int CalculateStat(int baseStat, int level)
+    {
+        return Mathf.FloorToInt(((2 * baseStat) * level) / 100f) + 5;
+    }
+}

--- a/Assets/Scripts/Pokemon/PokemonInstance.cs.meta
+++ b/Assets/Scripts/Pokemon/PokemonInstance.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2bf74177-2a9e-4bb1-9f2c-c289277a2752
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Pokemon/PokemonParty.cs
+++ b/Assets/Scripts/Pokemon/PokemonParty.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PokemonParty : MonoBehaviour
+{
+    [SerializeField] private int maxSize = 6;
+    private readonly List<PokemonInstance> members = new();
+
+    public IReadOnlyList<PokemonInstance> Members => members;
+
+    public bool Add(PokemonInstance pokemon)
+    {
+        if (pokemon == null || members.Count >= maxSize)
+            return false;
+        members.Add(pokemon);
+        return true;
+    }
+
+    public bool Remove(PokemonInstance pokemon)
+    {
+        return members.Remove(pokemon);
+    }
+
+    public void Swap(int indexA, int indexB)
+    {
+        if (indexA < 0 || indexA >= members.Count || indexB < 0 || indexB >= members.Count)
+            return;
+        (members[indexA], members[indexB]) = (members[indexB], members[indexA]);
+    }
+
+    public PokemonInstance this[int index] => members[index];
+}

--- a/Assets/Scripts/Pokemon/PokemonParty.cs.meta
+++ b/Assets/Scripts/Pokemon/PokemonParty.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ddec3365-ae7f-46af-8db3-ab35be9455d1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Add ScriptableObjects for base stats, species definitions, and centralized database
- Implement level-aware Pokémon instances and party component shared by player and trainers
- Provide CSV importer and sample data table for defining Pokémon species
- Attach PokemonParty to player prefab

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b7800759a4832087d6d0ecff624471