### PR TITLE
Add Pokemon definitions and level-based stat calculation

### DIFF
--- a/Assets/Pokemon.meta
+++ b/Assets/Pokemon.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ebcb5a32687441c182c9ca383e39c54d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Pokemon/PokemonDefinition.cs
+++ b/Assets/Pokemon/PokemonDefinition.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+[System.Serializable]
+public class PokemonDefinition
+{
+    public string id;
+    public string displayName;
+    [TextArea]
+    public string description;
+    public PokemonBaseStats baseStats;
+}
+
+[CreateAssetMenu(fileName = "PokemonDatabase", menuName = "PKMN/Pokemon Database")]
+public class PokemonDatabase : ScriptableObject
+{
+    public List<PokemonDefinition> pokemon;
+
+    public PokemonDefinition GetById(string id)
+    {
+        return pokemon.Find(p => p.id == id);
+    }
+}

--- a/Assets/Pokemon/PokemonDefinition.cs.meta
+++ b/Assets/Pokemon/PokemonDefinition.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6b4f4125669b4ab5bf920ea8ecbea839

--- a/Assets/Pokemon/PokemonInstance.cs
+++ b/Assets/Pokemon/PokemonInstance.cs
@@ -1,0 +1,13 @@
+public class PokemonInstance
+{
+    public PokemonDefinition definition;
+    public int level;
+
+    public PokemonStats Stats => PokemonStatCalculator.Calculate(definition.baseStats, level);
+
+    public PokemonInstance(PokemonDefinition definition, int level)
+    {
+        this.definition = definition;
+        this.level = level;
+    }
+}

--- a/Assets/Pokemon/PokemonInstance.cs.meta
+++ b/Assets/Pokemon/PokemonInstance.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f714cf71419a46f98ab5406507176e89

--- a/Assets/Pokemon/PokemonStats.cs
+++ b/Assets/Pokemon/PokemonStats.cs
@@ -1,0 +1,48 @@
+using UnityEngine;
+
+[System.Serializable]
+public struct PokemonBaseStats
+{
+    public int hp;
+    public int attack;
+    public int defense;
+    public int specialAttack;
+    public int specialDefense;
+    public int speed;
+}
+
+[System.Serializable]
+public struct PokemonStats
+{
+    public int hp;
+    public int attack;
+    public int defense;
+    public int specialAttack;
+    public int specialDefense;
+    public int speed;
+}
+
+public static class PokemonStatCalculator
+{
+    public static PokemonStats Calculate(PokemonBaseStats baseStats, int level)
+    {
+        PokemonStats result;
+        result.hp = CalculateHP(baseStats.hp, level);
+        result.attack = CalculateOther(baseStats.attack, level);
+        result.defense = CalculateOther(baseStats.defense, level);
+        result.specialAttack = CalculateOther(baseStats.specialAttack, level);
+        result.specialDefense = CalculateOther(baseStats.specialDefense, level);
+        result.speed = CalculateOther(baseStats.speed, level);
+        return result;
+    }
+
+    private static int CalculateHP(int baseStat, int level)
+    {
+        return Mathf.FloorToInt(((2 * baseStat) * level) / 100f) + level + 10;
+    }
+
+    private static int CalculateOther(int baseStat, int level)
+    {
+        return Mathf.FloorToInt(((2 * baseStat) * level) / 100f) + 5;
+    }
+}

--- a/Assets/Pokemon/PokemonStats.cs.meta
+++ b/Assets/Pokemon/PokemonStats.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: eadf8f0f67134a7d90bd80f217fefc2c


### PR DESCRIPTION
## Summary
- Define Pokemon with name, description, and base stats
- Scriptable database to organize Pokemon entries and lookup by id
- Utility for calculating level-based stats and creating leveled Pokemon instances

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b788870d808320b62ca7364f59a492