### PR TITLE
Add effect support for ability overrides and rampage moves

### DIFF
--- a/Assets/Pokemon.meta
+++ b/Assets/Pokemon.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ebcb5a32687441c182c9ca383e39c54d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Pokemon/AbilityDefinition.cs
+++ b/Assets/Pokemon/AbilityDefinition.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+[System.Serializable]
+public class AbilityDefinition
+{
+    public string id;
+    public string name;
+    [TextArea]
+    public string summary;
+    public List<EffectHook> hooks;
+}
+
+[CreateAssetMenu(fileName = "AbilityDatabase", menuName = "PKMN/Ability Database")]
+public class AbilityDatabase : ScriptableObject
+{
+    public List<AbilityDefinition> abilities;
+
+    public AbilityDefinition GetById(string id)
+    {
+        return abilities.Find(a => a.id == id);
+    }
+}

--- a/Assets/Pokemon/AbilityDefinition.cs.meta
+++ b/Assets/Pokemon/AbilityDefinition.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3fe53ad60d114382a7c825dd5c5a44dd

--- a/Assets/Pokemon/BattlePokemon.cs
+++ b/Assets/Pokemon/BattlePokemon.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+
+public class BattlePokemon
+{
+    public PokemonInstance instance;
+
+    private string currentAbility;
+    private string originalAbility;
+
+    private List<string> statuses = new List<string>();
+
+    private string rampageMoveId;
+    private int rampageTurnsRemaining;
+    private string rampagePostStatus;
+
+    private static Random rng = new Random();
+
+    public BattlePokemon(PokemonInstance instance)
+    {
+        this.instance = instance;
+        currentAbility = instance.Abilities.Count > 0 ? instance.Abilities[0] : null;
+        originalAbility = currentAbility;
+    }
+
+    public string CurrentAbility => currentAbility;
+    public IReadOnlyList<string> Statuses => statuses;
+
+    public void SetAbility(string abilityId)
+    {
+        currentAbility = abilityId;
+    }
+
+    public void RestoreOriginalAbility()
+    {
+        currentAbility = originalAbility;
+    }
+
+    public void OnSwitchOut()
+    {
+        rampageMoveId = null;
+        rampageTurnsRemaining = 0;
+        rampagePostStatus = null;
+        RestoreOriginalAbility();
+    }
+
+    public void StartRampage(string moveId, int minTurns, int maxTurns, string postStatus)
+    {
+        rampageMoveId = moveId;
+        rampageTurnsRemaining = rng.Next(minTurns, maxTurns + 1);
+        rampagePostStatus = postStatus;
+    }
+
+    public string GetForcedMove()
+    {
+        return rampageMoveId;
+    }
+
+    public void AdvanceTurn()
+    {
+        if (rampageMoveId != null)
+        {
+            rampageTurnsRemaining--;
+            if (rampageTurnsRemaining <= 0)
+            {
+                rampageMoveId = null;
+                if (!string.IsNullOrEmpty(rampagePostStatus))
+                    statuses.Add(rampagePostStatus);
+                rampagePostStatus = null;
+            }
+        }
+    }
+}

--- a/Assets/Pokemon/EffectCatalog.cs
+++ b/Assets/Pokemon/EffectCatalog.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+[System.Serializable]
+public class EffectCatalogEntry
+{
+    public string id;
+    [TextArea]
+    public string argsJson;
+}
+
+[CreateAssetMenu(fileName = "EffectCatalog", menuName = "PKMN/Effect Catalog")]
+public class EffectCatalog : ScriptableObject
+{
+    public List<EffectCatalogEntry> effectsCatalog;
+
+    public EffectCatalogEntry GetById(string id)
+    {
+        return effectsCatalog.Find(e => e.id == id);
+    }
+}

--- a/Assets/Pokemon/EffectCatalog.cs.meta
+++ b/Assets/Pokemon/EffectCatalog.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a41783ddbf154c19990d10b101d63178

--- a/Assets/Pokemon/EffectData.cs
+++ b/Assets/Pokemon/EffectData.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+[System.Serializable]
+public class EffectData
+{
+    public string effect;
+    [TextArea]
+    public string argsJson;
+}

--- a/Assets/Pokemon/EffectData.cs.meta
+++ b/Assets/Pokemon/EffectData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 66ea5edbb41b4c148952597463adc35a

--- a/Assets/Pokemon/EffectHook.cs
+++ b/Assets/Pokemon/EffectHook.cs
@@ -1,0 +1,8 @@
+using UnityEngine;
+
+[System.Serializable]
+public class EffectHook
+{
+    public string trigger;
+    public EffectData effect;
+}

--- a/Assets/Pokemon/EffectHook.cs.meta
+++ b/Assets/Pokemon/EffectHook.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7cf1cfcc3e704a2fab219ceb3c0f27dd

--- a/Assets/Pokemon/EffectResolver.cs
+++ b/Assets/Pokemon/EffectResolver.cs
@@ -1,0 +1,35 @@
+using UnityEngine;
+
+public static class EffectResolver
+{
+    [System.Serializable]
+    private class SetAbilityArgs
+    {
+        public string abilityId;
+    }
+
+    [System.Serializable]
+    private class RampageArgs
+    {
+        public int minTurns;
+        public int maxTurns;
+        public string postStatus;
+    }
+
+    public static void ApplyEffect(BattlePokemon user, BattlePokemon target, MoveDefinition move, EffectData data)
+    {
+        switch (data.effect)
+        {
+            case "SetAbility":
+                var sa = JsonUtility.FromJson<SetAbilityArgs>(data.argsJson);
+                if (sa != null)
+                    target.SetAbility(sa.abilityId);
+                break;
+            case "Rampage":
+                var ra = JsonUtility.FromJson<RampageArgs>(data.argsJson);
+                if (ra != null)
+                    user.StartRampage(move.id, ra.minTurns, ra.maxTurns, ra.postStatus);
+                break;
+        }
+    }
+}

--- a/Assets/Pokemon/MoveDefinition.cs
+++ b/Assets/Pokemon/MoveDefinition.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+[System.Serializable]
+public class MoveDefinition
+{
+    public string id;
+    public string name;
+    public PokemonType type;
+    public MoveCategory category;
+    public int power;
+    public int accuracy;
+    public int pp;
+    public List<EffectData> effects;
+}
+
+[CreateAssetMenu(fileName = "MoveDatabase", menuName = "PKMN/Move Database")]
+public class MoveDatabase : ScriptableObject
+{
+    public List<MoveDefinition> moves;
+
+    public MoveDefinition GetById(string id)
+    {
+        return moves.Find(m => m.id == id);
+    }
+}

--- a/Assets/Pokemon/MoveDefinition.cs.meta
+++ b/Assets/Pokemon/MoveDefinition.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0b89a9a21e03491cb3de6156ab950137

--- a/Assets/Pokemon/PokemonDefinition.cs
+++ b/Assets/Pokemon/PokemonDefinition.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+[System.Serializable]
+public class LearnsetEntry
+{
+    public int level;
+    public List<string> moves;
+}
+
+[System.Serializable]
+public class Evolution
+{
+    public string trigger;
+    public int minLevel;
+    public string to;
+}
+
+[System.Serializable]
+public class PokemonDefinition
+{
+    public string id;
+    public string displayName;
+    [TextArea]
+    public string description;
+    public PokemonType[] types;
+    public PokemonBaseStats baseStats;
+    public GrowthRate growthRate;
+    public int catchRate;
+    public int expYield;
+    public List<string> abilities;
+    public List<LearnsetEntry> learnset;
+    public List<Evolution> evolutions;
+}
+
+[CreateAssetMenu(fileName = "PokemonDatabase", menuName = "PKMN/Pokemon Database")]
+public class PokemonDatabase : ScriptableObject
+{
+    public List<PokemonDefinition> pokemon;
+
+    public PokemonDefinition GetById(string id)
+    {
+        return pokemon.Find(p => p.id == id);
+    }
+}

--- a/Assets/Pokemon/PokemonDefinition.cs
+++ b/Assets/Pokemon/PokemonDefinition.cs
@@ -19,27 +19,50 @@ public class Evolution
 [System.Serializable]
 public class PokemonDefinition
 {
-    public string id;
-    public string displayName;
-    [TextArea]
-    public string description;
-    public PokemonType[] types;
-    public PokemonBaseStats baseStats;
-    public GrowthRate growthRate;
-    public int catchRate;
-    public int expYield;
-    public List<string> abilities;
-    public List<LearnsetEntry> learnset;
-    public List<Evolution> evolutions;
+    [SerializeField]
+    private string id;
+    [SerializeField]
+    private string displayName;
+    [SerializeField, TextArea]
+    private string description;
+    [SerializeField]
+    private PokemonType[] types;
+    [SerializeField]
+    private PokemonBaseStats baseStats;
+    [SerializeField]
+    private GrowthRate growthRate;
+    [SerializeField]
+    private int catchRate;
+    [SerializeField]
+    private int expYield;
+    [SerializeField]
+    private List<string> abilities;
+    [SerializeField]
+    private List<LearnsetEntry> learnset;
+    [SerializeField]
+    private List<Evolution> evolutions;
+
+    public string Id => id;
+    public string DisplayName => displayName;
+    public string Description => description;
+    public IReadOnlyList<PokemonType> Types => types;
+    public PokemonBaseStats BaseStats => baseStats;
+    public GrowthRate GrowthRate => growthRate;
+    public int CatchRate => catchRate;
+    public int ExpYield => expYield;
+    public IReadOnlyList<string> Abilities => abilities;
+    public IReadOnlyList<LearnsetEntry> Learnset => learnset;
+    public IReadOnlyList<Evolution> Evolutions => evolutions;
 }
 
 [CreateAssetMenu(fileName = "PokemonDatabase", menuName = "PKMN/Pokemon Database")]
 public class PokemonDatabase : ScriptableObject
 {
-    public List<PokemonDefinition> pokemon;
+    [SerializeField]
+    private List<PokemonDefinition> pokemon = new();
 
     public PokemonDefinition GetById(string id)
     {
-        return pokemon.Find(p => p.id == id);
+        return pokemon.Find(p => p.Id == id);
     }
 }

--- a/Assets/Pokemon/PokemonDefinition.cs.meta
+++ b/Assets/Pokemon/PokemonDefinition.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6b4f4125669b4ab5bf920ea8ecbea839

--- a/Assets/Pokemon/PokemonEnums.cs
+++ b/Assets/Pokemon/PokemonEnums.cs
@@ -1,0 +1,41 @@
+using System;
+
+public enum PokemonType
+{
+    Normal,
+    Fire,
+    Water,
+    Grass,
+    Electric,
+    Ice,
+    Fighting,
+    Poison,
+    Ground,
+    Flying,
+    Psychic,
+    Bug,
+    Rock,
+    Ghost,
+    Dragon,
+    Dark,
+    Steel,
+    Fairy
+}
+
+public enum MoveCategory
+{
+    Physical,
+    Special,
+    Status
+}
+
+public enum GrowthRate
+{
+    Slow,
+    Medium,
+    Fast,
+    MediumSlow,
+    MediumFast,
+    FastThenVerySlow,
+    SlowThenVeryFast
+}

--- a/Assets/Pokemon/PokemonEnums.cs.meta
+++ b/Assets/Pokemon/PokemonEnums.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5cc6bdae4fd64da0a7efad5cbf358490

--- a/Assets/Pokemon/PokemonInstance.cs
+++ b/Assets/Pokemon/PokemonInstance.cs
@@ -3,19 +3,21 @@ using System.Linq;
 
 public class PokemonInstance
 {
-    public PokemonDefinition definition;
-    public int level;
+    private PokemonDefinition definition;
+    private int level;
 
     private List<string> moveSet;
     private List<string> learnableMoves;
 
     private static System.Random rng = new System.Random();
 
-    public PokemonStats Stats => PokemonStatCalculator.Calculate(definition.baseStats, level);
+    public PokemonDefinition Definition => definition;
+    public int Level => level;
+    public PokemonStats Stats => PokemonStatCalculator.Calculate(definition.BaseStats, level);
     public IReadOnlyList<string> Moves => moveSet;
     public IReadOnlyList<string> LearnableMoves => learnableMoves;
-    public IReadOnlyList<string> Abilities => definition.abilities;
-    public IReadOnlyList<PokemonType> Types => definition.types;
+    public IReadOnlyList<string> Abilities => definition.Abilities;
+    public IReadOnlyList<PokemonType> Types => definition.Types;
 
     public PokemonInstance(PokemonDefinition definition, int level)
     {
@@ -29,9 +31,9 @@ public class PokemonInstance
     private List<string> GetMovesForLevel(int targetLevel)
     {
         var learned = new HashSet<string>();
-        if (definition.learnset == null)
+        if (definition.Learnset == null)
             return learned.ToList();
-        foreach (var entry in definition.learnset)
+        foreach (var entry in definition.Learnset)
         {
             if (entry.level <= targetLevel)
             {

--- a/Assets/Pokemon/PokemonInstance.cs
+++ b/Assets/Pokemon/PokemonInstance.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+using System.Linq;
+
+public class PokemonInstance
+{
+    public PokemonDefinition definition;
+    public int level;
+
+    private List<string> moveSet;
+    private List<string> learnableMoves;
+
+    private static System.Random rng = new System.Random();
+
+    public PokemonStats Stats => PokemonStatCalculator.Calculate(definition.baseStats, level);
+    public IReadOnlyList<string> Moves => moveSet;
+    public IReadOnlyList<string> LearnableMoves => learnableMoves;
+    public IReadOnlyList<string> Abilities => definition.abilities;
+    public IReadOnlyList<PokemonType> Types => definition.types;
+
+    public PokemonInstance(PokemonDefinition definition, int level)
+    {
+        this.definition = definition;
+        this.level = level;
+
+        learnableMoves = GetMovesForLevel(level);
+        moveSet = GenerateRandomMoveLoadout(learnableMoves);
+    }
+
+    private List<string> GetMovesForLevel(int targetLevel)
+    {
+        var learned = new HashSet<string>();
+        if (definition.learnset == null)
+            return learned.ToList();
+        foreach (var entry in definition.learnset)
+        {
+            if (entry.level <= targetLevel)
+            {
+                foreach (var move in entry.moves)
+                    learned.Add(move);
+            }
+        }
+        return learned.ToList();
+    }
+
+    private List<string> GenerateRandomMoveLoadout(List<string> available)
+    {
+        var result = new List<string>(available);
+        if (result.Count <= 4)
+            return result;
+
+        // Fisher-Yates shuffle then take first four
+        int n = result.Count;
+        while (n > 1)
+        {
+            int k = rng.Next(n--);
+            (result[n], result[k]) = (result[k], result[n]);
+        }
+        return result.GetRange(0, 4);
+    }
+}

--- a/Assets/Pokemon/PokemonInstance.cs.meta
+++ b/Assets/Pokemon/PokemonInstance.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f714cf71419a46f98ab5406507176e89

--- a/Assets/Pokemon/PokemonStats.cs
+++ b/Assets/Pokemon/PokemonStats.cs
@@ -1,0 +1,48 @@
+using UnityEngine;
+
+[System.Serializable]
+public struct PokemonBaseStats
+{
+    public int hp;
+    public int attack;
+    public int defense;
+    public int specialAttack;
+    public int specialDefense;
+    public int speed;
+}
+
+[System.Serializable]
+public struct PokemonStats
+{
+    public int hp;
+    public int attack;
+    public int defense;
+    public int specialAttack;
+    public int specialDefense;
+    public int speed;
+}
+
+public static class PokemonStatCalculator
+{
+    public static PokemonStats Calculate(PokemonBaseStats baseStats, int level)
+    {
+        PokemonStats result;
+        result.hp = CalculateHP(baseStats.hp, level);
+        result.attack = CalculateOther(baseStats.attack, level);
+        result.defense = CalculateOther(baseStats.defense, level);
+        result.specialAttack = CalculateOther(baseStats.specialAttack, level);
+        result.specialDefense = CalculateOther(baseStats.specialDefense, level);
+        result.speed = CalculateOther(baseStats.speed, level);
+        return result;
+    }
+
+    private static int CalculateHP(int baseStat, int level)
+    {
+        return Mathf.FloorToInt(((2 * baseStat) * level) / 100f) + level + 10;
+    }
+
+    private static int CalculateOther(int baseStat, int level)
+    {
+        return Mathf.FloorToInt(((2 * baseStat) * level) / 100f) + 5;
+    }
+}

--- a/Assets/Pokemon/PokemonStats.cs.meta
+++ b/Assets/Pokemon/PokemonStats.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: eadf8f0f67134a7d90bd80f217fefc2c

--- a/Assets/Pokemon/StatusDefinition.cs
+++ b/Assets/Pokemon/StatusDefinition.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+[System.Serializable]
+public class StatusDefinition
+{
+    public string id;
+    public int minDuration;
+    public int maxDuration;
+    public List<EffectHook> hooks;
+}
+
+[CreateAssetMenu(fileName = "StatusDatabase", menuName = "PKMN/Status Database")]
+public class StatusDatabase : ScriptableObject
+{
+    public List<StatusDefinition> statuses;
+
+    public StatusDefinition GetById(string id)
+    {
+        return statuses.Find(s => s.id == id);
+    }
+}

--- a/Assets/Pokemon/StatusDefinition.cs.meta
+++ b/Assets/Pokemon/StatusDefinition.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 44fc9c4b5f404b449c19c09e7dbb2c2a


### PR DESCRIPTION
## Summary
- introduce `BattlePokemon` runtime to track temporary ability overrides and rampage state
- add `EffectResolver` that applies new `SetAbility` and `Rampage` effects

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b788870d808320b62ca7364f59a492