### PR TITLE
refactor: reference move effects by catalog id

### DIFF
--- a/Assets/Pokemon/EffectData.cs
+++ b/Assets/Pokemon/EffectData.cs
@@ -3,7 +3,10 @@ using UnityEngine;
 [System.Serializable]
 public class EffectData
 {
-    public string effect;
+    // ID of the effect entry in the EffectCatalog
+    public string effectId;
+
+    // Optional JSON overrides for the catalog entry's arguments
     [TextArea]
-    public string argsJson;
+    public string overrideArgsJson;
 }

--- a/Assets/Pokemon/EffectResolver.cs
+++ b/Assets/Pokemon/EffectResolver.cs
@@ -16,17 +16,21 @@ public static class EffectResolver
         public string postStatus;
     }
 
-    public static void ApplyEffect(BattlePokemon user, BattlePokemon target, MoveDefinition move, EffectData data)
+    public static void ApplyEffect(EffectCatalog catalog, BattlePokemon user, BattlePokemon target, MoveDefinition move, EffectData data)
     {
-        switch (data.effect)
+        // Resolve arguments from the catalog entry unless the move overrides them
+        var entry = catalog != null ? catalog.GetById(data.effectId) : null;
+        var argsJson = string.IsNullOrEmpty(data.overrideArgsJson) ? entry?.argsJson : data.overrideArgsJson;
+
+        switch (data.effectId)
         {
             case "SetAbility":
-                var sa = JsonUtility.FromJson<SetAbilityArgs>(data.argsJson);
+                var sa = JsonUtility.FromJson<SetAbilityArgs>(argsJson);
                 if (sa != null)
                     target.SetAbility(sa.abilityId);
                 break;
             case "Rampage":
-                var ra = JsonUtility.FromJson<RampageArgs>(data.argsJson);
+                var ra = JsonUtility.FromJson<RampageArgs>(argsJson);
                 if (ra != null)
                     user.StartRampage(move.id, ra.minTurns, ra.maxTurns, ra.postStatus);
                 break;

--- a/Assets/Pokemon/MoveDefinition.cs
+++ b/Assets/Pokemon/MoveDefinition.cs
@@ -11,6 +11,7 @@ public class MoveDefinition
     public int power;
     public int accuracy;
     public int pp;
+    // IDs of effects to apply from the EffectCatalog along with optional argument overrides
     public List<EffectData> effects;
 }
 


### PR DESCRIPTION
## Summary
- refactor EffectData to hold a catalog entry ID and optional JSON override
- resolve move effects through EffectCatalog in EffectResolver
- document effect catalog usage in MoveDefinition

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d03b99408320913cd5b614859ac4