### PR TITLE
Split effect scripts and fix editor wizard field names

### DIFF
--- a/Assets/Pokemon/BattlePokemon.cs
+++ b/Assets/Pokemon/BattlePokemon.cs
@@ -79,7 +79,7 @@ public class BattlePokemon
     {
         if (statusDb == null)
             return;
-        foreach (var s in statuses)
+        foreach (var s in statuses.ToArray())
         {
             var def = statusDb.GetById(s.id);
             if (def == null || def.hooks == null)


### PR DESCRIPTION
## Summary
- Move each battle effect into its own script so Unity can load assets like RecoilEffect and StatusEffect
- Rename fields in move and ability creator wizards to avoid hiding Object.name
- Extract StatusDatabase into its own script
- Iterate over a copy of statuses when running hooks to allow safe mutation

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c05f8aa0832084ba4cf786ea772e