### PR TITLE
Initialize lists in databases to prevent wizard errors

### DIFF
--- a/Assets/Pokemon/AbilityDefinition.cs
+++ b/Assets/Pokemon/AbilityDefinition.cs
@@ -8,13 +8,13 @@ public class AbilityDefinition
     public string name;
     [TextArea]
     public string summary;
-    public List<EffectHook> hooks;
+    public List<EffectHook> hooks = new();
 }
 
 [CreateAssetMenu(fileName = "AbilityDatabase", menuName = "PKMN/Ability Database")]
 public class AbilityDatabase : ScriptableObject
 {
-    public List<AbilityDefinition> abilities;
+    public List<AbilityDefinition> abilities = new();
 
     public AbilityDefinition GetById(string id)
     {

--- a/Assets/Pokemon/BattleEffect.cs
+++ b/Assets/Pokemon/BattleEffect.cs
@@ -1,211 +1,23 @@
 using UnityEngine;
 
-public class BattleContext
+namespace PKMN
 {
-    // Flag that prevents a Pokemon from acting this turn
-    public bool preventMove;
-    // Multiplier applied to move power during damage calculation
-    public float powerMultiplier = 1f;
-}
-
-public abstract class BattleEffect : ScriptableObject
-{
-    public virtual void Apply(BattlePokemon user, BattlePokemon target, MoveDefinition move, BattleContext context)
+    public class BattleContext
     {
+        // Flag that prevents a Pokemon from acting this turn
+        public bool preventMove;
+        // Multiplier applied to move power during damage calculation
+        public float powerMultiplier = 1f;
+        // Id of a status currently being attempted
+        public string statusId;
+        // Flag that blocks the status from being applied
+        public bool preventStatus;
     }
-}
 
-[CreateAssetMenu(menuName="PKMN/Effects/Damage")]
-public class DamageEffect : BattleEffect
-{
-    public override void Apply(BattlePokemon user, BattlePokemon target, MoveDefinition move, BattleContext context)
+    public abstract class BattleEffect : ScriptableObject
     {
-        if (target != null)
-            target.ModifyHP(-move.power);
-    }
-}
-
-public enum Stat
-{
-    Attack,
-    Defense,
-    SpecialAttack,
-    SpecialDefense,
-    Speed,
-    Accuracy,
-    Evasion
-}
-
-[CreateAssetMenu(menuName="PKMN/Effects/Stat Stage")]
-public class StatStageEffect : BattleEffect
-{
-    public Stat stat;
-    public int stages;
-    public bool targetSelf;
-
-    public override void Apply(BattlePokemon user, BattlePokemon target, MoveDefinition move, BattleContext context)
-    {
-        var p = targetSelf ? user : target;
-        p?.SetStatStage(stat, stages);
-    }
-}
-
-[CreateAssetMenu(menuName="PKMN/Effects/Status")]
-public class StatusEffect : BattleEffect
-{
-    public string statusId;
-    public bool targetSelf;
-
-    public override void Apply(BattlePokemon user, BattlePokemon target, MoveDefinition move, BattleContext context)
-    {
-        var p = targetSelf ? user : target;
-        p?.ApplyStatus(statusId, 0, user);
-    }
-}
-
-[CreateAssetMenu(menuName="PKMN/Effects/Heal")]
-public class HealEffect : BattleEffect
-{
-    [Range(0f,1f)] public float fraction = 0.5f;
-    public bool targetSelf = true;
-
-    public override void Apply(BattlePokemon user, BattlePokemon target, MoveDefinition move, BattleContext context)
-    {
-        var p = targetSelf ? user : target;
-        if (p != null)
+        public virtual void Apply(BattlePokemon user, BattlePokemon target, MoveDefinition move, BattleContext context)
         {
-            int amount = Mathf.RoundToInt(p.MaxHP * fraction);
-            p.ModifyHP(amount);
         }
-    }
-}
-
-[CreateAssetMenu(menuName="PKMN/Effects/Recoil")]
-public class RecoilEffect : BattleEffect
-{
-    [Range(0f,1f)] public float fraction = 0.25f;
-
-    public override void Apply(BattlePokemon user, BattlePokemon target, MoveDefinition move, BattleContext context)
-    {
-        user?.QueueRecoil(fraction);
-    }
-}
-
-[CreateAssetMenu(menuName="PKMN/Effects/Force Ability")]
-public class ForceAbilityEffect : BattleEffect
-{
-    public string abilityId;
-    public override void Apply(BattlePokemon user, BattlePokemon target, MoveDefinition move, BattleContext context)
-    {
-        target?.SetAbility(abilityId);
-    }
-}
-
-[CreateAssetMenu(menuName="PKMN/Effects/Charge")]
-public class ChargeEffect : BattleEffect
-{
-    public override void Apply(BattlePokemon user, BattlePokemon target, MoveDefinition move, BattleContext context)
-    {
-        user?.StartCharge(move);
-    }
-}
-
-[CreateAssetMenu(menuName="PKMN/Effects/Rampage")]
-public class RampageEffect : BattleEffect
-{
-    public int minTurns = 2;
-    public int maxTurns = 3;
-    public string postStatus;
-
-    public override void Apply(BattlePokemon user, BattlePokemon target, MoveDefinition move, BattleContext context)
-    {
-        user?.StartRampage(move.id, minTurns, maxTurns, postStatus);
-    }
-}
-
-[CreateAssetMenu(menuName="PKMN/Effects/HP Percent Damage")]
-public class HPPercentDamageEffect : BattleEffect
-{
-    [Range(0f,1f)] public float fraction = 0.125f;
-    public bool targetSelf;
-
-    public override void Apply(BattlePokemon user, BattlePokemon target, MoveDefinition move, BattleContext context)
-    {
-        var p = targetSelf ? user : target;
-        if (p != null)
-        {
-            int dmg = Mathf.RoundToInt(p.MaxHP * fraction);
-            p.ModifyHP(-dmg);
-        }
-    }
-}
-
-[CreateAssetMenu(menuName="PKMN/Effects/Prevent Action")]
-public class PreventActionEffect : BattleEffect
-{
-    public override void Apply(BattlePokemon user, BattlePokemon target, MoveDefinition move, BattleContext context)
-    {
-        if (context != null)
-            context.preventMove = true;
-    }
-}
-
-[CreateAssetMenu(menuName="PKMN/Effects/Drain")]
-public class DrainEffect : BattleEffect
-{
-    [Range(0f,1f)] public float fraction = 0.125f;
-
-    public override void Apply(BattlePokemon user, BattlePokemon target, MoveDefinition move, BattleContext context)
-    {
-        if (user == null || target == null)
-            return;
-        int dmg = Mathf.RoundToInt(target.MaxHP * fraction);
-        target.ModifyHP(-dmg);
-        user.ModifyHP(dmg);
-    }
-}
-
-[CreateAssetMenu(menuName="PKMN/Effects/Self Hit Chance")]
-public class SelfHitChanceEffect : BattleEffect
-{
-    [Range(0f,1f)] public float chance = 0.33f;
-    public int power = 40;
-
-    public override void Apply(BattlePokemon user, BattlePokemon target, MoveDefinition move, BattleContext context)
-    {
-        if (user == null || context == null)
-            return;
-        if (UnityEngine.Random.value < chance)
-        {
-            user.ModifyHP(-power);
-            context.preventMove = true;
-        }
-    }
-}
-
-[CreateAssetMenu(menuName="PKMN/Effects/Power Multiplier")]
-public class PowerMultiplierEffect : BattleEffect
-{
-    public PokemonType type;
-    [Range(0f,1f)] public float hpThreshold = 1f;
-    public float multiplier = 1f;
-
-    public override void Apply(BattlePokemon user, BattlePokemon target, MoveDefinition move, BattleContext context)
-    {
-        if (user == null || move == null || context == null)
-            return;
-        if (move.type == type && user.CurrentHP <= user.MaxHP * hpThreshold)
-            context.powerMultiplier *= multiplier;
-    }
-}
-
-[CreateAssetMenu(menuName="PKMN/Effects/Set Speed Multiplier")]
-public class SetSpeedMultiplierEffect : BattleEffect
-{
-    public float multiplier = 2f;
-
-    public override void Apply(BattlePokemon user, BattlePokemon target, MoveDefinition move, BattleContext context)
-    {
-        user?.SetSpeedMultiplier(multiplier);
     }
 }

--- a/Assets/Pokemon/BattleEvent.cs
+++ b/Assets/Pokemon/BattleEvent.cs
@@ -7,5 +7,6 @@ public enum BattleEvent
     AfterMove,
     CalculateDamage,
     WeatherChanged,
-    TurnEnd
+    TurnEnd,
+    BeforeStatus
 }

--- a/Assets/Pokemon/BattleEventManager.cs
+++ b/Assets/Pokemon/BattleEventManager.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using PKMN;
 
 public class BattleEventManager
 {

--- a/Assets/Pokemon/BattlePokemon.cs
+++ b/Assets/Pokemon/BattlePokemon.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine;
+using PKMN;
 
 public class BattlePokemon
 {
@@ -22,15 +23,17 @@ public class BattlePokemon
     private string rampagePostStatus;
 
     private readonly StatusDatabase statusDb;
+    private readonly AbilityDatabase abilityDb;
     private float speedMultiplier = 1f;
 
     public int MaxHP { get; }
     public int CurrentHP { get; private set; }
 
-    public BattlePokemon(PokemonInstance instance, StatusDatabase statusDb = null)
+    public BattlePokemon(PokemonInstance instance, StatusDatabase statusDb = null, AbilityDatabase abilityDb = null)
     {
         this.instance = instance;
         this.statusDb = statusDb;
+        this.abilityDb = abilityDb;
         currentAbility = instance.Abilities.Count > 0 ? instance.Abilities[0] : null;
         originalAbility = currentAbility;
         MaxHP = instance.Stats.hp;
@@ -60,6 +63,12 @@ public class BattlePokemon
 
     public void ApplyStatus(string id, int duration, BattlePokemon source = null)
     {
+        var context = new BattleContext { statusId = id };
+        source?.RunAbilityHooks(BattleEvent.BeforeStatus, this, null, context);
+        RunAbilityHooks(BattleEvent.BeforeStatus, source, null, context);
+        if (context.preventStatus)
+            return;
+
         int dur = duration;
         if (dur <= 0 && statusDb != null)
         {
@@ -100,8 +109,24 @@ public class BattlePokemon
         }
     }
 
+    internal void RunAbilityHooks(BattleEvent evt, BattlePokemon opponent, MoveDefinition move, BattleContext context)
+    {
+        if (abilityDb == null || string.IsNullOrEmpty(currentAbility))
+            return;
+        var def = abilityDb.GetById(currentAbility);
+        if (def == null || def.hooks == null)
+            return;
+        foreach (var hook in def.hooks)
+        {
+            if (hook.trigger != evt)
+                continue;
+            hook.effect?.Apply(this, opponent, move, context);
+        }
+    }
+
     public bool BeforeMove(BattlePokemon opponent, MoveDefinition move, BattleContext context)
     {
+        RunAbilityHooks(BattleEvent.BeforeMove, opponent, move, context);
         RunStatusHooks(BattleEvent.BeforeMove, opponent, move, context);
         return context == null || !context.preventMove;
     }
@@ -151,6 +176,7 @@ public class BattlePokemon
 
     public void AdvanceTurn(BattlePokemon opponent)
     {
+        RunAbilityHooks(BattleEvent.TurnEnd, opponent, null, new BattleContext());
         RunStatusHooks(BattleEvent.TurnEnd, opponent, null, new BattleContext());
 
         if (rampageMoveId != null)

--- a/Assets/Pokemon/Editor/DataCreationWizards.cs
+++ b/Assets/Pokemon/Editor/DataCreationWizards.cs
@@ -2,6 +2,7 @@
 using UnityEditor;
 using UnityEngine;
 using System.Collections.Generic;
+using PKMN;
 
 /// <summary>
 /// Utility helpers for loading or creating database assets.
@@ -26,7 +27,7 @@ static class DatabaseLoader
 public class MoveCreatorWizard : ScriptableWizard
 {
     public string id;
-    public string name;
+    public new string name;
     public PokemonType type;
     public MoveCategory category;
     public int power;
@@ -63,7 +64,7 @@ public class MoveCreatorWizard : ScriptableWizard
 public class AbilityCreatorWizard : ScriptableWizard
 {
     public string id;
-    public string name;
+    public new string name;
     [TextArea]
     public string summary;
     public EffectHook[] hooks;

--- a/Assets/Pokemon/EffectHook.cs
+++ b/Assets/Pokemon/EffectHook.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using PKMN;
 
 [System.Serializable]
 public class EffectHook

--- a/Assets/Pokemon/Effects/ChargeEffect.cs
+++ b/Assets/Pokemon/Effects/ChargeEffect.cs
@@ -1,10 +1,13 @@
 using UnityEngine;
 
-[CreateAssetMenu(menuName="PKMN/Effects/Charge")]
-public class ChargeEffect : BattleEffect
+namespace PKMN
 {
-    public override void Apply(BattlePokemon user, BattlePokemon target, MoveDefinition move, BattleContext context)
+    [CreateAssetMenu(menuName="PKMN/Effects/Charge")]
+    public class ChargeEffect : BattleEffect
     {
-        user?.StartCharge(move);
+        public override void Apply(BattlePokemon user, BattlePokemon target, MoveDefinition move, BattleContext context)
+        {
+            user?.StartCharge(move);
+        }
     }
 }

--- a/Assets/Pokemon/Effects/DamageEffect.cs
+++ b/Assets/Pokemon/Effects/DamageEffect.cs
@@ -1,11 +1,14 @@
 using UnityEngine;
 
-[CreateAssetMenu(menuName="PKMN/Effects/Damage")]
-public class DamageEffect : BattleEffect
+namespace PKMN
 {
-    public override void Apply(BattlePokemon user, BattlePokemon target, MoveDefinition move, BattleContext context)
+    [CreateAssetMenu(menuName="PKMN/Effects/Damage")]
+    public class DamageEffect : BattleEffect
     {
-        if (target != null)
-            target.ModifyHP(-move.power);
+        public override void Apply(BattlePokemon user, BattlePokemon target, MoveDefinition move, BattleContext context)
+        {
+            if (target != null)
+                target.ModifyHP(-move.power);
+        }
     }
 }

--- a/Assets/Pokemon/Effects/DrainEffect.cs
+++ b/Assets/Pokemon/Effects/DrainEffect.cs
@@ -1,16 +1,19 @@
 using UnityEngine;
 
-[CreateAssetMenu(menuName="PKMN/Effects/Drain")]
-public class DrainEffect : BattleEffect
+namespace PKMN
 {
-    [Range(0f,1f)] public float fraction = 0.125f;
-
-    public override void Apply(BattlePokemon user, BattlePokemon target, MoveDefinition move, BattleContext context)
+    [CreateAssetMenu(menuName="PKMN/Effects/Drain")]
+    public class DrainEffect : BattleEffect
     {
-        if (user == null || target == null)
-            return;
-        int dmg = Mathf.RoundToInt(target.MaxHP * fraction);
-        target.ModifyHP(-dmg);
-        user.ModifyHP(dmg);
+        [Range(0f,1f)] public float fraction = 0.125f;
+
+        public override void Apply(BattlePokemon user, BattlePokemon target, MoveDefinition move, BattleContext context)
+        {
+            if (user == null || target == null)
+                return;
+            int dmg = Mathf.RoundToInt(target.MaxHP * fraction);
+            target.ModifyHP(-dmg);
+            user.ModifyHP(dmg);
+        }
     }
 }

--- a/Assets/Pokemon/Effects/ForceAbilityEffect.cs
+++ b/Assets/Pokemon/Effects/ForceAbilityEffect.cs
@@ -1,12 +1,15 @@
 using UnityEngine;
 
-[CreateAssetMenu(menuName="PKMN/Effects/Force Ability")]
-public class ForceAbilityEffect : BattleEffect
+namespace PKMN
 {
-    public string abilityId;
-
-    public override void Apply(BattlePokemon user, BattlePokemon target, MoveDefinition move, BattleContext context)
+    [CreateAssetMenu(menuName="PKMN/Effects/Force Ability")]
+    public class ForceAbilityEffect : BattleEffect
     {
-        target?.SetAbility(abilityId);
+        public string abilityId;
+
+        public override void Apply(BattlePokemon user, BattlePokemon target, MoveDefinition move, BattleContext context)
+        {
+            target?.SetAbility(abilityId);
+        }
     }
 }

--- a/Assets/Pokemon/Effects/HPPercentDamageEffect.cs
+++ b/Assets/Pokemon/Effects/HPPercentDamageEffect.cs
@@ -1,18 +1,21 @@
 using UnityEngine;
 
-[CreateAssetMenu(menuName="PKMN/Effects/HP Percent Damage")]
-public class HPPercentDamageEffect : BattleEffect
+namespace PKMN
 {
-    [Range(0f,1f)] public float fraction = 0.125f;
-    public bool targetSelf;
-
-    public override void Apply(BattlePokemon user, BattlePokemon target, MoveDefinition move, BattleContext context)
+    [CreateAssetMenu(menuName="PKMN/Effects/HP Percent Damage")]
+    public class HPPercentDamageEffect : BattleEffect
     {
-        var p = targetSelf ? user : target;
-        if (p != null)
+        [Range(0f,1f)] public float fraction = 0.125f;
+        public bool targetSelf;
+
+        public override void Apply(BattlePokemon user, BattlePokemon target, MoveDefinition move, BattleContext context)
         {
-            int dmg = Mathf.RoundToInt(p.MaxHP * fraction);
-            p.ModifyHP(-dmg);
+            var p = targetSelf ? user : target;
+            if (p != null)
+            {
+                int dmg = Mathf.RoundToInt(p.MaxHP * fraction);
+                p.ModifyHP(-dmg);
+            }
         }
     }
 }

--- a/Assets/Pokemon/Effects/HealEffect.cs
+++ b/Assets/Pokemon/Effects/HealEffect.cs
@@ -1,18 +1,21 @@
 using UnityEngine;
 
-[CreateAssetMenu(menuName="PKMN/Effects/Heal")]
-public class HealEffect : BattleEffect
+namespace PKMN
 {
-    [Range(0f,1f)] public float fraction = 0.5f;
-    public bool targetSelf = true;
-
-    public override void Apply(BattlePokemon user, BattlePokemon target, MoveDefinition move, BattleContext context)
+    [CreateAssetMenu(menuName="PKMN/Effects/Heal")]
+    public class HealEffect : BattleEffect
     {
-        var p = targetSelf ? user : target;
-        if (p != null)
+        [Range(0f,1f)] public float fraction = 0.5f;
+        public bool targetSelf = true;
+
+        public override void Apply(BattlePokemon user, BattlePokemon target, MoveDefinition move, BattleContext context)
         {
-            int amount = Mathf.RoundToInt(p.MaxHP * fraction);
-            p.ModifyHP(amount);
+            var p = targetSelf ? user : target;
+            if (p != null)
+            {
+                int amount = Mathf.RoundToInt(p.MaxHP * fraction);
+                p.ModifyHP(amount);
+            }
         }
     }
 }

--- a/Assets/Pokemon/Effects/PowerMultiplierEffect.cs
+++ b/Assets/Pokemon/Effects/PowerMultiplierEffect.cs
@@ -1,17 +1,20 @@
 using UnityEngine;
 
-[CreateAssetMenu(menuName="PKMN/Effects/Power Multiplier")]
-public class PowerMultiplierEffect : BattleEffect
+namespace PKMN
 {
-    public PokemonType type;
-    [Range(0f,1f)] public float hpThreshold = 1f;
-    public float multiplier = 1f;
-
-    public override void Apply(BattlePokemon user, BattlePokemon target, MoveDefinition move, BattleContext context)
+    [CreateAssetMenu(menuName="PKMN/Effects/Power Multiplier")]
+    public class PowerMultiplierEffect : BattleEffect
     {
-        if (user == null || move == null || context == null)
-            return;
-        if (move.type == type && user.CurrentHP <= user.MaxHP * hpThreshold)
-            context.powerMultiplier *= multiplier;
+        public PokemonType type;
+        [Range(0f,1f)] public float hpThreshold = 1f;
+        public float multiplier = 1f;
+
+        public override void Apply(BattlePokemon user, BattlePokemon target, MoveDefinition move, BattleContext context)
+        {
+            if (user == null || move == null || context == null)
+                return;
+            if (move.type == type && user.CurrentHP <= user.MaxHP * hpThreshold)
+                context.powerMultiplier *= multiplier;
+        }
     }
 }

--- a/Assets/Pokemon/Effects/PreventActionEffect.cs
+++ b/Assets/Pokemon/Effects/PreventActionEffect.cs
@@ -1,11 +1,14 @@
 using UnityEngine;
 
-[CreateAssetMenu(menuName="PKMN/Effects/Prevent Action")]
-public class PreventActionEffect : BattleEffect
+namespace PKMN
 {
-    public override void Apply(BattlePokemon user, BattlePokemon target, MoveDefinition move, BattleContext context)
+    [CreateAssetMenu(menuName="PKMN/Effects/Prevent Action")]
+    public class PreventActionEffect : BattleEffect
     {
-        if (context != null)
-            context.preventMove = true;
+        public override void Apply(BattlePokemon user, BattlePokemon target, MoveDefinition move, BattleContext context)
+        {
+            if (context != null)
+                context.preventMove = true;
+        }
     }
 }

--- a/Assets/Pokemon/Effects/PreventStatusEffect.cs
+++ b/Assets/Pokemon/Effects/PreventStatusEffect.cs
@@ -1,0 +1,18 @@
+using UnityEngine;
+
+namespace PKMN
+{
+    [CreateAssetMenu(menuName="PKMN/Effects/PreventStatus")]
+    public class PreventStatusEffect : BattleEffect
+    {
+        public string statusId;
+
+        public override void Apply(BattlePokemon user, BattlePokemon target, MoveDefinition move, BattleContext context)
+        {
+            if (context != null && context.statusId == statusId)
+            {
+                context.preventStatus = true;
+            }
+        }
+    }
+}

--- a/Assets/Pokemon/Effects/RampageEffect.cs
+++ b/Assets/Pokemon/Effects/RampageEffect.cs
@@ -1,14 +1,17 @@
 using UnityEngine;
 
-[CreateAssetMenu(menuName="PKMN/Effects/Rampage")]
-public class RampageEffect : BattleEffect
+namespace PKMN
 {
-    public int minTurns = 2;
-    public int maxTurns = 3;
-    public string postStatus;
-
-    public override void Apply(BattlePokemon user, BattlePokemon target, MoveDefinition move, BattleContext context)
+    [CreateAssetMenu(menuName="PKMN/Effects/Rampage")]
+    public class RampageEffect : BattleEffect
     {
-        user?.StartRampage(move.id, minTurns, maxTurns, postStatus);
+        public int minTurns = 2;
+        public int maxTurns = 3;
+        public string postStatus;
+
+        public override void Apply(BattlePokemon user, BattlePokemon target, MoveDefinition move, BattleContext context)
+        {
+            user?.StartRampage(move.id, minTurns, maxTurns, postStatus);
+        }
     }
 }

--- a/Assets/Pokemon/Effects/RecoilEffect.cs
+++ b/Assets/Pokemon/Effects/RecoilEffect.cs
@@ -1,12 +1,15 @@
 using UnityEngine;
 
-[CreateAssetMenu(menuName="PKMN/Effects/Recoil")]
-public class RecoilEffect : BattleEffect
+namespace PKMN
 {
-    [Range(0f,1f)] public float fraction = 0.25f;
-
-    public override void Apply(BattlePokemon user, BattlePokemon target, MoveDefinition move, BattleContext context)
+    [CreateAssetMenu(menuName="PKMN/Effects/Recoil")]
+    public class RecoilEffect : BattleEffect
     {
-        user?.QueueRecoil(fraction);
+        [Range(0f,1f)] public float fraction = 0.25f;
+
+        public override void Apply(BattlePokemon user, BattlePokemon target, MoveDefinition move, BattleContext context)
+        {
+            user?.QueueRecoil(fraction);
+        }
     }
 }

--- a/Assets/Pokemon/Effects/SelfHitChanceEffect.cs
+++ b/Assets/Pokemon/Effects/SelfHitChanceEffect.cs
@@ -1,19 +1,22 @@
 using UnityEngine;
 
-[CreateAssetMenu(menuName="PKMN/Effects/Self Hit Chance")]
-public class SelfHitChanceEffect : BattleEffect
+namespace PKMN
 {
-    [Range(0f,1f)] public float chance = 0.33f;
-    public int power = 40;
-
-    public override void Apply(BattlePokemon user, BattlePokemon target, MoveDefinition move, BattleContext context)
+    [CreateAssetMenu(menuName="PKMN/Effects/Self Hit Chance")]
+    public class SelfHitChanceEffect : BattleEffect
     {
-        if (user == null || context == null)
-            return;
-        if (UnityEngine.Random.value < chance)
+        [Range(0f,1f)] public float chance = 0.33f;
+        public int power = 40;
+
+        public override void Apply(BattlePokemon user, BattlePokemon target, MoveDefinition move, BattleContext context)
         {
-            user.ModifyHP(-power);
-            context.preventMove = true;
+            if (user == null || context == null)
+                return;
+            if (UnityEngine.Random.value < chance)
+            {
+                user.ModifyHP(-power);
+                context.preventMove = true;
+            }
         }
     }
 }

--- a/Assets/Pokemon/Effects/SetSpeedMultiplierEffect.cs
+++ b/Assets/Pokemon/Effects/SetSpeedMultiplierEffect.cs
@@ -1,12 +1,15 @@
 using UnityEngine;
 
-[CreateAssetMenu(menuName="PKMN/Effects/Set Speed Multiplier")]
-public class SetSpeedMultiplierEffect : BattleEffect
+namespace PKMN
 {
-    public float multiplier = 2f;
-
-    public override void Apply(BattlePokemon user, BattlePokemon target, MoveDefinition move, BattleContext context)
+    [CreateAssetMenu(menuName="PKMN/Effects/Set Speed Multiplier")]
+    public class SetSpeedMultiplierEffect : BattleEffect
     {
-        user?.SetSpeedMultiplier(multiplier);
+        public float multiplier = 2f;
+
+        public override void Apply(BattlePokemon user, BattlePokemon target, MoveDefinition move, BattleContext context)
+        {
+            user?.SetSpeedMultiplier(multiplier);
+        }
     }
 }

--- a/Assets/Pokemon/Effects/StatStageEffect.cs
+++ b/Assets/Pokemon/Effects/StatStageEffect.cs
@@ -1,15 +1,18 @@
 using UnityEngine;
 
-[CreateAssetMenu(menuName="PKMN/Effects/Stat Stage")]
-public class StatStageEffect : BattleEffect
+namespace PKMN
 {
-    public Stat stat;
-    public int stages;
-    public bool targetSelf;
-
-    public override void Apply(BattlePokemon user, BattlePokemon target, MoveDefinition move, BattleContext context)
+    [CreateAssetMenu(menuName="PKMN/Effects/Stat Stage")]
+    public class StatStageEffect : BattleEffect
     {
-        var p = targetSelf ? user : target;
-        p?.SetStatStage(stat, stages);
+        public Stat stat;
+        public int stages;
+        public bool targetSelf;
+
+        public override void Apply(BattlePokemon user, BattlePokemon target, MoveDefinition move, BattleContext context)
+        {
+            var p = targetSelf ? user : target;
+            p?.SetStatStage(stat, stages);
+        }
     }
 }

--- a/Assets/Pokemon/Effects/StatusEffect.cs
+++ b/Assets/Pokemon/Effects/StatusEffect.cs
@@ -1,14 +1,17 @@
 using UnityEngine;
 
-[CreateAssetMenu(menuName="PKMN/Effects/Status")]
-public class StatusEffect : BattleEffect
+namespace PKMN
 {
-    public string statusId;
-    public bool targetSelf;
-
-    public override void Apply(BattlePokemon user, BattlePokemon target, MoveDefinition move, BattleContext context)
+    [CreateAssetMenu(menuName="PKMN/Effects/Status")]
+    public class StatusEffect : BattleEffect
     {
-        var p = targetSelf ? user : target;
-        p?.ApplyStatus(statusId, 0, user);
+        public string statusId;
+        public bool targetSelf;
+
+        public override void Apply(BattlePokemon user, BattlePokemon target, MoveDefinition move, BattleContext context)
+        {
+            var p = targetSelf ? user : target;
+            p?.ApplyStatus(statusId, 0, user);
+        }
     }
 }

--- a/Assets/Pokemon/MoveDefinition.cs
+++ b/Assets/Pokemon/MoveDefinition.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using UnityEngine;
+using PKMN;
 
 [System.Serializable]
 public class MoveDefinition
@@ -11,13 +12,13 @@ public class MoveDefinition
     public int power;
     public int accuracy;
     public int pp;
-    public List<BattleEffect> effects;
+    public List<BattleEffect> effects = new();
 }
 
 [CreateAssetMenu(fileName = "MoveDatabase", menuName = "PKMN/Move Database")]
 public class MoveDatabase : ScriptableObject
 {
-    public List<MoveDefinition> moves;
+    public List<MoveDefinition> moves = new();
 
     public MoveDefinition GetById(string id)
     {

--- a/Assets/Pokemon/StatusDatabase.cs
+++ b/Assets/Pokemon/StatusDatabase.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 [CreateAssetMenu(fileName = "StatusDatabase", menuName = "PKMN/Status Database")]
 public class StatusDatabase : ScriptableObject
 {
-    public List<StatusDefinition> statuses;
+    public List<StatusDefinition> statuses = new();
 
     public StatusDefinition GetById(string id)
     {

--- a/Assets/Pokemon/StatusDefinition.cs
+++ b/Assets/Pokemon/StatusDefinition.cs
@@ -7,7 +7,7 @@ public class StatusDefinition
     public string id;
     public int minDuration;
     public int maxDuration;
-    public List<EffectHook> hooks;
+    public List<EffectHook> hooks = new();
 }
 
 // Database class moved to StatusDatabase.cs


### PR DESCRIPTION
## Summary
- Initialize hook/effect lists in ability, move, and status definitions
- Ensure AbilityDatabase, MoveDatabase, and StatusDatabase start with empty lists to avoid null references

## Testing
- `dotnet test` *(command not found)*
- `apt-get update` *(repositories returned 403/unsigned errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b8cc0a62a083209ed6176db42e84c6