### PR TITLE
Remove duplicated move and ability database classes

### DIFF
--- a/Assets/Pokemon/AbilityDefinition.cs
+++ b/Assets/Pokemon/AbilityDefinition.cs
@@ -10,14 +10,4 @@ public class AbilityDefinition
     public string summary;
     public List<EffectHook> hooks = new();
 }
-
-[CreateAssetMenu(fileName = "AbilityDatabase", menuName = "PKMN/Ability Database")]
-public class AbilityDatabase : ScriptableObject
-{
-    public List<AbilityDefinition> abilities = new();
-
-    public AbilityDefinition GetById(string id)
-    {
-        return abilities.Find(a => a.id == id);
-    }
-}
+// Database class moved to AbilityDatabase.cs

--- a/Assets/Pokemon/MoveDefinition.cs
+++ b/Assets/Pokemon/MoveDefinition.cs
@@ -14,14 +14,4 @@ public class MoveDefinition
     public int pp;
     public List<BattleEffect> effects = new();
 }
-
-[CreateAssetMenu(fileName = "MoveDatabase", menuName = "PKMN/Move Database")]
-public class MoveDatabase : ScriptableObject
-{
-    public List<MoveDefinition> moves = new();
-
-    public MoveDefinition GetById(string id)
-    {
-        return moves.Find(m => m.id == id);
-    }
-}
+// Database class moved to MoveDatabase.cs


### PR DESCRIPTION
## Summary
- fix namespace duplicates by moving AbilityDatabase and MoveDatabase definitions to their own files

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b8fbb62f50832091932fb5b698d054