### PR TITLE
Separate PokemonDatabase script

### DIFF
--- a/Assets/Pokemon/PokemonDatabase.cs
+++ b/Assets/Pokemon/PokemonDatabase.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "PokemonDatabase", menuName = "PKMN/Pokemon Database")]
+public class PokemonDatabase : ScriptableObject
+{
+    public List<PokemonDefinition> pokemon = new();
+
+    public PokemonDefinition GetById(string id)
+    {
+        return pokemon.Find(p => p != null && p.Id == id);
+    }
+
+    public IReadOnlyList<PokemonDefinition> All => pokemon;
+}
+

--- a/Assets/Pokemon/PokemonDefinition.cs
+++ b/Assets/Pokemon/PokemonDefinition.cs
@@ -54,19 +54,3 @@ public class PokemonDefinition
 
 #endregion
 
-#region Database
-
-[CreateAssetMenu(fileName = "PokemonDatabase", menuName = "PKMN/Pokemon Database")]
-public class PokemonDatabase : ScriptableObject
-{
-public List<PokemonDefinition> pokemon = new();
-
-    public PokemonDefinition GetById(string id)
-    {
-        return pokemon.Find(p => p != null && p.Id == id);
-    }
-
-    public IReadOnlyList<PokemonDefinition> All => pokemon;
-}
-
-#endregion


### PR DESCRIPTION
## Summary
- Separate `PokemonDatabase` into its own script file so Unity can create the asset properly.
- Remove `PokemonDatabase` class from `PokemonDefinition` script.

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9173c50e8832097cdc9c91d6089b5