### PR TITLE
Allow custom tilemap names for encounter system

### DIFF
--- a/Assets/Encounters/EncounterTable.cs
+++ b/Assets/Encounters/EncounterTable.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+[System.Serializable]
+public class EncounterEntry
+{
+    public PokemonDefinition pokemon;
+    public int minLevel = 1;
+    public int maxLevel = 1;
+    public float weight = 1f;
+}
+
+public class EncounterTable : MonoBehaviour
+{
+    [Range(0f, 1f)]
+    public float encounterChance = 0.1f;
+    public List<EncounterEntry> encounters = new();
+
+    /// <summary>
+    /// Attempts to trigger a wild Pokémon encounter.
+    /// Logs the encountered Pokémon and level if successful.
+    /// </summary>
+    /// <returns>True if an encounter occurred.</returns>
+    public bool TryEncounter()
+    {
+        if (encounters.Count == 0)
+            return false;
+        if (Random.value > encounterChance)
+            return false;
+
+        float totalWeight = 0f;
+        foreach (var entry in encounters)
+            totalWeight += Mathf.Max(0f, entry.weight);
+
+        float roll = Random.value * totalWeight;
+        foreach (var entry in encounters)
+        {
+            roll -= Mathf.Max(0f, entry.weight);
+            if (roll <= 0f)
+            {
+                int level = Random.Range(entry.minLevel, entry.maxLevel + 1);
+                string name = entry.pokemon ? entry.pokemon.DisplayName : "Unknown";
+                Debug.Log($"Encountered Pokémon: {name} (Lv {level})");
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/Assets/Encounters/EncounterTable.cs.meta
+++ b/Assets/Encounters/EncounterTable.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 11bc752662bc46048c451ad6276f4c84

--- a/Assets/Encounters/EncounterTrigger.cs
+++ b/Assets/Encounters/EncounterTrigger.cs
@@ -1,0 +1,71 @@
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.Tilemaps;
+
+/// <summary>
+/// Checks for tall grass steps and triggers encounters using the active EncounterTable.
+/// Attach to the persistent player so encounters work across scenes.
+/// </summary>
+[RequireComponent(typeof(GridMover2D))]
+public class EncounterTrigger : MonoBehaviour, IGridBound
+{
+    [SerializeField] private GridMover2D mover;
+    [SerializeField] private Tilemap grassTilemap;
+    [SerializeField] private string grassTilemapName = "GrassBehind";
+
+    private EncounterTable table;
+    private Grid currentGrid;
+
+    private void Awake()
+    {
+        if (!mover) mover = GetComponent<GridMover2D>();
+        mover.OnStepFinished += HandleStep;
+    }
+
+    private void OnDestroy()
+    {
+        if (mover != null) mover.OnStepFinished -= HandleStep;
+    }
+
+    private void OnEnable()
+    {
+        SceneManager.sceneLoaded += OnSceneLoaded;
+        RebindSceneRefs();
+    }
+
+    private void OnDisable()
+    {
+        SceneManager.sceneLoaded -= OnSceneLoaded;
+    }
+
+    private void OnSceneLoaded(Scene scene, LoadSceneMode mode)
+    {
+        RebindSceneRefs();
+    }
+
+    private void RebindSceneRefs()
+    {
+        table = FindObjectOfType<EncounterTable>();
+        if (!grassTilemap || !grassTilemap.gameObject.scene.IsValid())
+            grassTilemap = GameObject.Find(grassTilemapName)?.GetComponent<Tilemap>();
+        currentGrid = mover ? mover.CurrentGrid : null;
+    }
+
+    public void Rebind(Grid newGrid)
+    {
+        currentGrid = newGrid;
+    }
+
+    private void HandleStep(Vector3Int cell)
+    {
+        if (table == null || grassTilemap == null || currentGrid == null)
+            return;
+
+        Vector3 worldCenter = currentGrid.GetCellCenterWorld(cell);
+        Vector3Int grassCell = grassTilemap.layoutGrid.WorldToCell(worldCenter);
+        if (grassTilemap.HasTile(grassCell))
+        {
+            table.TryEncounter();
+        }
+    }
+}

--- a/Assets/Encounters/EncounterTrigger.cs.meta
+++ b/Assets/Encounters/EncounterTrigger.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7a27f8b7165b4a688b45fa6e50b9d35d

--- a/Assets/GrassFrontSwapper.cs
+++ b/Assets/GrassFrontSwapper.cs
@@ -7,6 +7,8 @@ public class GrassFrontSwapper : MonoBehaviour, IGridBound
     [Header("Scene refs (required)")]
     [SerializeField] private Tilemap grassBehind;    // ORDER 1: all bushes painted here at start
     [SerializeField] private Tilemap grassFront;     // ORDER 3: starts EMPTY
+    [SerializeField] private string behindTilemapName = "GrassBehind";
+    [SerializeField] private string frontTilemapName = "GrassFront";
     private Grid playerGrid;                         // The Grid your map/mover use (parent of tilemaps)
 
     [Header("Player (required)")]
@@ -75,10 +77,10 @@ public class GrassFrontSwapper : MonoBehaviour, IGridBound
             playerGrid = playerMover.CurrentGrid;
 
         if (!grassBehind || !grassBehind.gameObject.scene.IsValid())
-            grassBehind = GameObject.Find("GrassBehind")?.GetComponent<Tilemap>();
+            grassBehind = GameObject.Find(behindTilemapName)?.GetComponent<Tilemap>();
 
         if (!grassFront || !grassFront.gameObject.scene.IsValid())
-            grassFront = GameObject.Find("GrassFront")?.GetComponent<Tilemap>();
+            grassFront = GameObject.Find(frontTilemapName)?.GetComponent<Tilemap>();
 
         if (playerGrid && grassBehind && grassFront)
             HandleStepFinished(GetFeetCellInMoverGrid());


### PR DESCRIPTION
## Summary
- Expose grass tilemap lookup name in `EncounterTrigger`
- Add customizable behind/front tilemap names in `GrassFrontSwapper`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d5af8ed08320ace94a966727fd0f