### PR TITLE
Randomize Pokemon move loadout selection

### DIFF
--- a/Assets/Pokemon/PokemonInstance.cs
+++ b/Assets/Pokemon/PokemonInstance.cs
@@ -57,8 +57,10 @@ public class PokemonInstance
         if (available == null || available.Count == 0)
             return new List<string>();
 
-        // Take the last four moves learned to mirror main-series behavior
         int count = Mathf.Min(4, available.Count);
-        return available.Skip(available.Count - count).Take(count).ToList();
+
+        // Randomly select up to four distinct moves from the available list
+        var shuffled = available.OrderBy(_ => Random.value).ToList();
+        return shuffled.Take(count).ToList();
     }
 }


### PR DESCRIPTION
## Summary
- Randomly select up to four distinct moves from a Pokémon's available learnset when creating an instance

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba48440c488320afee2867082d8839