### PR TITLE
feat: add held item support and selection events

### DIFF
--- a/Assets/Pokemon/Editor/PokemonPartyEditor.cs
+++ b/Assets/Pokemon/Editor/PokemonPartyEditor.cs
@@ -1,0 +1,64 @@
+#if UNITY_EDITOR
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+[CustomPropertyDrawer(typeof(PokemonParty.Slot))]
+public class PokemonPartySlotDrawer : PropertyDrawer
+{
+    public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+    {
+        // Base height plus four lines for moves when a Pokémon is selected
+        var idProp = property.FindPropertyRelative("pokemonId");
+        bool hasPokemon = !string.IsNullOrEmpty(idProp.stringValue);
+        int lines = hasPokemon ? 3 + 4 : 2; // pokemon + level + held item + moves
+        return EditorGUIUtility.singleLineHeight * lines + EditorGUIUtility.standardVerticalSpacing * (lines - 1);
+    }
+
+    public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+    {
+        EditorGUI.BeginProperty(position, label, property);
+        var idProp = property.FindPropertyRelative("pokemonId");
+        var levelProp = property.FindPropertyRelative("level");
+        var itemProp = property.FindPropertyRelative("heldItem");
+        var movesProp = property.FindPropertyRelative("moves");
+
+        var line = new Rect(position.x, position.y, position.width, EditorGUIUtility.singleLineHeight);
+        EditorGUI.PropertyField(line, idProp, new GUIContent("Pokémon"));
+        line.y += EditorGUIUtility.singleLineHeight + EditorGUIUtility.standardVerticalSpacing;
+        EditorGUI.PropertyField(line, levelProp, new GUIContent("Level"));
+        line.y += EditorGUIUtility.singleLineHeight + EditorGUIUtility.standardVerticalSpacing;
+        EditorGUI.PropertyField(line, itemProp, new GUIContent("Held Item"));
+
+        if (!string.IsNullOrEmpty(idProp.stringValue))
+        {
+            var party = property.serializedObject.targetObject as PokemonParty;
+            PokemonDefinition def = party != null && party.Database != null ? party.Database.GetById(idProp.stringValue) : null;
+
+            List<string> moves = new();
+            if (def != null && def.Learnset != null)
+            {
+                foreach (var entry in def.Learnset)
+                {
+                    if (entry?.moves == null) continue;
+                    foreach (var m in entry.moves)
+                        if (!string.IsNullOrWhiteSpace(m) && !moves.Contains(m))
+                            moves.Add(m);
+                }
+            }
+            moves.Insert(0, string.Empty);
+            movesProp.arraySize = 4;
+            for (int i = 0; i < 4; i++)
+            {
+                line.y += EditorGUIUtility.singleLineHeight + EditorGUIUtility.standardVerticalSpacing;
+                var moveProp = movesProp.GetArrayElementAtIndex(i);
+                int selected = Mathf.Max(0, moves.IndexOf(moveProp.stringValue));
+                selected = EditorGUI.Popup(line, $"Move {i + 1}", selected, moves.ToArray());
+                moveProp.stringValue = moves[selected];
+            }
+        }
+
+        EditorGUI.EndProperty();
+    }
+}
+#endif

--- a/Assets/Pokemon/Editor/PokemonPartyEditor.cs.meta
+++ b/Assets/Pokemon/Editor/PokemonPartyEditor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d06ba247d72949f4a74cb64eab268c30

--- a/Assets/Pokemon/PokemonInstance.cs
+++ b/Assets/Pokemon/PokemonInstance.cs
@@ -9,6 +9,7 @@ public class PokemonInstance
 
     private readonly List<string> moveSet;
     private readonly List<string> learnableMoves;
+    private string heldItem;
 
     public PokemonDefinition Definition => definition;
     public int Level => level;
@@ -19,6 +20,7 @@ public class PokemonInstance
     public IReadOnlyList<string> LearnableMoves => learnableMoves;
     public IReadOnlyList<string> Abilities => definition.Abilities;
     public IReadOnlyList<PokemonType> Types => definition.Types;
+    public string HeldItem => heldItem;
 
     public PokemonInstance(PokemonDefinition definition, int level)
     {
@@ -27,6 +29,26 @@ public class PokemonInstance
 
         learnableMoves = GetMovesForLevel(this.level);
         moveSet = GenerateMoveLoadout(learnableMoves);
+    }
+
+    public PokemonInstance(PokemonDefinition definition, int level, IEnumerable<string> movesOverride)
+    {
+        this.definition = definition;
+        this.level = Mathf.Clamp(level, 1, 100);
+
+        learnableMoves = GetMovesForLevel(this.level);
+        if (movesOverride != null)
+        {
+            moveSet = movesOverride
+                .Where(m => !string.IsNullOrWhiteSpace(m))
+                .Distinct()
+                .Take(4)
+                .ToList();
+        }
+        else
+        {
+            moveSet = GenerateMoveLoadout(learnableMoves);
+        }
     }
 
     private List<string> GetMovesForLevel(int targetLevel)
@@ -62,5 +84,10 @@ public class PokemonInstance
         // Randomly select up to four distinct moves from the available list
         var shuffled = available.OrderBy(_ => Random.value).ToList();
         return shuffled.Take(count).ToList();
+    }
+
+    public void SetHeldItem(string itemId)
+    {
+        heldItem = string.IsNullOrWhiteSpace(itemId) ? null : itemId;
     }
 }

--- a/Assets/Pokemon/PokemonParty.cs
+++ b/Assets/Pokemon/PokemonParty.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Holds a collection of Pokémon for a trainer or the player.
+/// The first slot represents the active Pokémon when entering battle.
+/// </summary>
+public class PokemonParty : MonoBehaviour
+{
+    [Serializable]
+    public class Slot
+    {
+        [PokemonId] public string pokemonId;
+        [Range(1,100)] public int level = 5;
+        public string heldItem;
+        [SerializeField] public List<string> moves = new();
+    }
+
+    [SerializeField] private PokemonDatabase pokemonDatabase;
+    [SerializeField] private List<Slot> startingMembers = new();
+
+    private readonly List<PokemonInstance> members = new();
+    public IReadOnlyList<PokemonInstance> Members => members;
+    public PokemonDatabase Database => pokemonDatabase;
+
+    public PokemonInstance ActivePokemon => members.Count > 0 ? members[0] : null;
+
+    public int SelectedIndex { get; private set; }
+    public PokemonInstance Selected => (SelectedIndex >= 0 && SelectedIndex < members.Count) ? members[SelectedIndex] : null;
+
+    public event Action OnPartyUpdated;
+    public event Action<int> OnSelectionChanged;
+
+    private void Awake()
+    {
+        Initialize();
+    }
+
+    /// <summary>
+    /// Builds the runtime party list from the inspector configuration.
+    /// </summary>
+    public void Initialize()
+    {
+        members.Clear();
+        if (pokemonDatabase == null)
+            return;
+
+        foreach (var slot in startingMembers)
+        {
+            if (string.IsNullOrWhiteSpace(slot.pokemonId))
+                continue;
+            var def = pokemonDatabase.GetById(slot.pokemonId);
+            if (def == null)
+                continue;
+            var inst = new PokemonInstance(def, slot.level, slot.moves);
+            inst.SetHeldItem(slot.heldItem);
+            members.Add(inst);
+        }
+        if (members.Count == 0)
+            SelectedIndex = -1;
+        else
+            SelectedIndex = Mathf.Clamp(SelectedIndex, 0, members.Count - 1);
+        OnPartyUpdated?.Invoke();
+        OnSelectionChanged?.Invoke(SelectedIndex);
+    }
+
+    /// <summary>
+    /// Adds a Pokémon to the party if space is available.
+    /// </summary>
+    public bool AddPokemon(string pokemonId, int level, IEnumerable<string> moves = null, string heldItem = null)
+    {
+        if (pokemonDatabase == null || members.Count >= 6)
+            return false;
+        var def = pokemonDatabase.GetById(pokemonId);
+        if (def == null)
+            return false;
+        var inst = new PokemonInstance(def, level, moves);
+        inst.SetHeldItem(heldItem);
+        members.Add(inst);
+        OnPartyUpdated?.Invoke();
+        return true;
+    }
+
+    public void RemoveAt(int index)
+    {
+        if (index < 0 || index >= members.Count)
+            return;
+        members.RemoveAt(index);
+        if (SelectedIndex >= members.Count)
+            SelectedIndex = members.Count - 1;
+        OnPartyUpdated?.Invoke();
+        OnSelectionChanged?.Invoke(SelectedIndex);
+    }
+
+    public void Swap(int a, int b)
+    {
+        if (a < 0 || b < 0 || a >= members.Count || b >= members.Count || a == b)
+            return;
+        (members[a], members[b]) = (members[b], members[a]);
+        int previousSelection = SelectedIndex;
+        if (SelectedIndex == a)
+            SelectedIndex = b;
+        else if (SelectedIndex == b)
+            SelectedIndex = a;
+        OnPartyUpdated?.Invoke();
+        if (previousSelection != SelectedIndex)
+            OnSelectionChanged?.Invoke(SelectedIndex);
+    }
+
+    public void SetSelectedIndex(int index)
+    {
+        if (index < 0 || index >= members.Count)
+            return;
+        SelectedIndex = index;
+        OnSelectionChanged?.Invoke(SelectedIndex);
+    }
+
+    public void NextSelection() => SetSelectedIndex(Mathf.Min(SelectedIndex + 1, members.Count - 1));
+    public void PreviousSelection() => SetSelectedIndex(Mathf.Max(SelectedIndex - 1, 0));
+}

--- a/Assets/Pokemon/PokemonParty.cs.meta
+++ b/Assets/Pokemon/PokemonParty.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4194ccf8a732485ba3fd6b31b8967649


### PR DESCRIPTION
## Summary
- support held items in `PokemonInstance` and party slots
- ensure swapping updates selected index and events
- fix party initialization when starting party is empty

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository unsigned)*

------
https://chatgpt.com/codex/tasks/task_e_68ba595caafc8320a49c074a3cf696a5